### PR TITLE
fix: issue when running inside queue worker

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -15,13 +15,14 @@ class Otp
 
     protected int $digits = 4;
 
-    protected int $time;
-
     public function __construct(Repository $store)
     {
-        $this->time = time();
-
         $this->store = $store;
+    }
+
+    protected function getFreshTime(): int
+    {
+        return time();
     }
 
     public function expiry($expiry): self
@@ -49,7 +50,7 @@ class Otp
     public function generate($key): string
     {
         $secret = sha1(uniqid());
-        $ttl = DateInterval::createFromDateString("{$this->time} seconds");
+        $ttl = DateInterval::createFromDateString("{$this->getFreshTime()} seconds");
         $this->store->put($this->keyFor($key), $secret, $ttl);
 
         return $this->calculate($secret);
@@ -66,7 +67,7 @@ class Otp
             return true;
         }
 
-        $factor = ($this->time - floor($this->expiry / 2)) / $this->expiry;
+        $factor = ($this->getFreshTime() - floor($this->expiry / 2)) / $this->expiry;
 
         return $code == $this->calculate($secret, $factor);
     }
@@ -100,7 +101,7 @@ class Otp
 
     protected function timeFactor($divisionFactor): string
     {
-        $factor = $divisionFactor ? floor($divisionFactor) : floor($this->time / $this->expiry);
+        $factor = $divisionFactor ? floor($divisionFactor) : floor($this->getFreshTime() / $this->expiry);
 
         $text = [];
         for ($i = 7; $i >= 0; $i--) {

--- a/tests/MockOtp.php
+++ b/tests/MockOtp.php
@@ -9,6 +9,8 @@ use Tzsk\Otp\Otp;
 
 class MockOtp extends Otp
 {
+    protected ?int $testTime = null;
+
     public function __construct()
     {
         $directory = './tests/phpunit-cache';
@@ -27,8 +29,17 @@ class MockOtp extends Otp
         return $this->digits;
     }
 
-    public function setTime($time)
+    public function setTestTime($time)
     {
-        $this->time = $time;
+        $this->testTime = $time;
+    }
+
+    protected function getFreshTime(): int
+    {
+        if($this->testTime) {
+            return $this->testTime;
+        }
+
+        return parent::getFreshTime();
     }
 }

--- a/tests/OtpTest.php
+++ b/tests/OtpTest.php
@@ -98,7 +98,7 @@ class OtpTest extends TestCase
     {
         $manager = new MockOtp();
         $otp = $manager->generate('foo');
-        $manager->setTime(time() + ($manager->getExpiry() * 100));
+        $manager->setTestTime(time() + ($manager->getExpiry() * 100));
 
         $this->assertFalse($manager->check($otp, 'foo'));
     }


### PR DESCRIPTION
Hi, @tzsk 

Thanks for creating this amazing package.

I was using the package without any issue unless i start using the `Otp` Facade inside queue worker (Queue Jobs etc).

The default expiry is 10 minutes, so everything works well for 10 minutes but all tokens found to be invalid which are generated after 10 minutes.

**Why?**
The `Otp` class stores current timestamp inside constructor which only gets called once, since the code is running inside worker.
All future generated OTP will use the same `time()` and result in expired tokens.

I have fixed the issue by calling the `time()` everytime when the class methods needs it.
I have also fixed the test case which was failing due to missing `$time` property.

Please review the suggested changes to fix the issue.
Thanks.
