### PR TITLE
Explicitly mark $directory as nullable in otp function to resolve PHP 8.1+ deprecation warning

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use Tzsk\Otp\Otp;
 
 if (! function_exists('otp')) {
-    function otp(string $directory = null): Otp
+    function otp(?string $directory = null): Otp
     {
         if ($directory) {
             $store = new Repository(new FileStore(new Filesystem(), $directory));


### PR DESCRIPTION
**Description:**  
This PR fixes a deprecation warning in PHP 8.1+ caused by the implicit nullable parameter `$directory` in the `otp` function. The warning occurs because PHP now requires explicitly marking nullable parameters with `?`.  

### **Changes Made:**  
- Updated the `otp` function signature in `src/Helper.php` from:  
  ```php
  function otp(string $directory = null): Otp
  ```
  to:  
  ```php
  function otp(?string $directory = null): Otp
  ```
- This ensures compatibility with PHP 8.1+ and prevents deprecation warnings.

### **Why This Is Needed:**  
- Without this change, users see a deprecation warning when running the package on PHP 8.1+.
- This update does not affect backward compatibility with older PHP versions.
- It aligns the function with best practices for defining nullable parameters.

### **Testing & Verification:**  
- Ensured that the function still works as expected with and without the `$directory` parameter.
- Checked compatibility with PHP versions prior to 8.1.