### PR TITLE
fix: use cryptographically secure random string for OTP secret

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -6,6 +6,7 @@ use Closure;
 use DateInterval;
 use Exception;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Str;
 
 /**
  * @method string make(string $key)
@@ -55,7 +56,7 @@ class Otp
 
     public function generate(string $key): string
     {
-        $secret = \Illuminate\Support\Str::random(40);
+        $secret = Str::random(40);
         $expiry = $this->expiry;
         /** @var DateInterval $ttl */
         $ttl = DateInterval::createFromDateString("{$expiry} seconds");

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -55,7 +55,7 @@ class Otp
 
     public function generate(string $key): string
     {
-        $secret = sha1(uniqid());
+        $secret = \Illuminate\Support\Str::random(40);
         $expiry = $this->expiry;
         /** @var DateInterval $ttl */
         $ttl = DateInterval::createFromDateString("{$expiry} seconds");


### PR DESCRIPTION
Replaced insecure `sha1(uniqid())` with Laravel's cryptographically secure `Str::random(40)` for OTP secret generation. Tested to ensure no regressions.

---
*PR created automatically by Jules for task [5039952836535321707](https://jules.google.com/task/5039952836535321707) started by @tzsk*